### PR TITLE
This adds an option to fix the element offset, which under some conditions seem not to be calculated correctly

### DIFF
--- a/src/wordcloud2.js
+++ b/src/wordcloud2.js
@@ -209,7 +209,9 @@ if (!window.clearImmediate) {
       classes: null,
 
       hover: null,
-      click: null
+      click: null,
+
+      fixElementOffset: false
     };
 
     if (options) {
@@ -756,13 +758,20 @@ if (!window.clearImmediate) {
               'translateX(-' + (info.fillTextWidth / 4) + 'px) ' +
               'scale(' + (1 / info.mu) + ')';
           }
+          
+          var styleRuleLeft = settings.fixElementOffset ? el.offsetLeft  : 0;
+          var styleRuleTop = settings.fixElementOffset ? el.offsetTop  : 0;
+
+          styleRuleLeft = styleRuleLeft + ((gx + info.gw / 2) * g + info.fillTextOffsetX) + 'px';
+          styleRuleTop = styleRuleTop + ((gy + info.gh / 2) * g + info.fillTextOffsetY) + 'px';
+
           var styleRules = {
             'position': 'absolute',
             'display': 'block',
             'font': settings.fontWeight + ' ' +
                     (fontSize * info.mu) + 'px ' + settings.fontFamily,
-            'left': ((gx + info.gw / 2) * g + info.fillTextOffsetX) + 'px',
-            'top': ((gy + info.gh / 2) * g + info.fillTextOffsetY) + 'px',
+            'left': styleRuleLeft,
+            'top': styleRuleTop,
             'width': info.fillTextWidth + 'px',
             'height': info.fillTextHeight + 'px',
             'lineHeight': fontSize + 'px',


### PR DESCRIPTION
The option `fixElementOffset` is added to the settings config. The default value is `false` which resembles the default behavior of the library.
Setting it to `true` adds `el.offsetLeft` and `el.offsetTop` accordingly and corrects the problem.